### PR TITLE
Add compatibility with Python 3.x

### DIFF
--- a/debug.py
+++ b/debug.py
@@ -4,7 +4,11 @@
 import debug: https://github.com/narfdotpl/debug
 """
 
-import __builtin__
+try:
+    import __builtin__
+except ImportError:
+    # Python 3.x
+    import builtins as __builtin__
 from sys import _getframe
 
 from ipdb import set_trace


### PR DESCRIPTION
Hi,

I noticed that "import debug" wasn't working with Python 3, so I added a simple ImportError catch to import __builtin__ from its new location.

I've tried it out in Python 3.1.5 and 3.2.2, and it seems to work there now

Cheers,
Arjen