### PR TITLE
Check import level

### DIFF
--- a/debug.py
+++ b/debug.py
@@ -34,7 +34,10 @@ debug()
 
 # monkeypatch `import` so `import debug` will work every time
 def new_import(*args, **kwargs):
-    if args[0] == 'debug':
+    name = args[0]
+    level = args[-1]
+    if name == 'debug' and level == 0:
+        # level 0 means only perform absolute imports
         debug()
     else:
         return old_import(*args, **kwargs)


### PR DESCRIPTION
Get `ImportError` when used with `readability-lxml` package. Following code

```
import debug
import readability
```

leads to
`ImportError: 'cannot import name describe'`

despite of [relative debug import](https://github.com/buriy/python-readability/blob/master/readability/readability.py#L20) in `readability.py` module.

This patch checks if debug was imported using absolute import.
