### PR TITLE
don't start debugger when some other "debug" module is imported using relative import

### DIFF
--- a/debug.py
+++ b/debug.py
@@ -34,7 +34,10 @@ debug()
 
 # monkeypatch `import` so `import debug` will work every time
 def new_import(*args, **kwargs):
-    if args[0] == 'debug':
+    name = args[0]
+    level = args[-1]
+    if name == 'debug' and level == 0:
+        # level 0 means only perform absolute imports
         debug()
     else:
         return old_import(*args, **kwargs)

--- a/debug.py
+++ b/debug.py
@@ -34,13 +34,34 @@ debug()
 
 # monkeypatch `import` so `import debug` will work every time
 def new_import(*args, **kwargs):
+    # don't touch non-debug imports
     name = args[0]
-    level = args[-1]
-    is_absolute = level is None or level == 0
-
-    if name == 'debug' and is_absolute:
-        debug()
-    else:
+    if name != 'debug':
         return old_import(*args, **kwargs)
+
+    # Make sure that the name "debug" refers to *this* module,
+    # i.e. that the import is `import debug` and not for example
+    # `from .debug import foo`.
+    #
+    # To check this I have to look at the value of the `level`
+    # argument.  It's the last argument and it has a default value.
+    # I don't want to add it to the signature of `new_import` because
+    # `__import__` is different in Python 2 and 3:
+    #
+    #     __import__(name, globals={}, locals={}, fromlist=[], level=-1)
+    #     __import__(name, globals=None, locals=None, fromlist=(), level=0)
+    #
+    # I work around this by getting `level` from `kwargs` and `args`,
+    # which works the same way in both Python versions.
+    is_relative = False
+    if 'level' in kwargs:
+        is_relative = kwargs['level'] > 0
+    elif len(args) == 5:
+        is_relative = args[-1] > 0
+
+    if is_relative:
+        return old_import(*args, **kwargs)
+    else:
+        debug()
 
 __builtin__.__import__ = new_import

--- a/debug.py
+++ b/debug.py
@@ -36,8 +36,9 @@ debug()
 def new_import(*args, **kwargs):
     name = args[0]
     level = args[-1]
-    if name == 'debug' and level == 0:
-        # level 0 means only perform absolute imports
+    is_absolute = level is None or level == 0
+
+    if name == 'debug' and is_absolute:
         debug()
     else:
         return old_import(*args, **kwargs)

--- a/manual_test.py
+++ b/manual_test.py
@@ -1,0 +1,7 @@
+print 1
+import debug
+print 2
+import debug
+print 3
+import manual_test_directory
+print 4

--- a/manual_test_directory/__init__.py
+++ b/manual_test_directory/__init__.py
@@ -1,0 +1,3 @@
+print 'manual_test_directory/__init__.py says hi'
+
+from .debug import x

--- a/manual_test_directory/debug.py
+++ b/manual_test_directory/debug.py
@@ -1,0 +1,3 @@
+print 'manual_test_directory/debug.py says hi'
+
+x = 0


### PR DESCRIPTION
Based on #7.

@qarkai, could you take a look?

In my testing `level` is `None`, when I use `import debug`. I added a few test files to verify it manually.

Before 5d930be the output is incorrect, the debugger is started only on the first import:

```
$ python manual_test.py
1
> /Users/narf/github/debug/manual_test.py(3)<module>()
      1 print 1
      2 import debug
----> 3 print 2
      4 import debug
      5 print 3

ipdb> c
2
3
manual_test_directory/__init__.py says hi
manual_test_directory/debug.py says hi
4
```

After 5d930be it works as expected:

```
$ python manual_test.py
1
> /Users/narf/github/debug/manual_test.py(3)<module>()
      1 print 1
      2 import debug
----> 3 print 2
      4 import debug
      5 print 3

ipdb> c
2
> /Users/narf/github/debug/manual_test.py(5)<module>()
      3 print 2
      4 import debug
----> 5 print 3
      6 import manual_test_directory
      7 print 4

ipdb> c
3
manual_test_directory/__init__.py says hi
manual_test_directory/debug.py says hi
4
```
